### PR TITLE
Fixed fps drop over time in WinterHoliday's Snowfall class

### DIFF
--- a/WinterHoliday/Snowfall.pde
+++ b/WinterHoliday/Snowfall.pde
@@ -52,7 +52,7 @@ class Snowfall {
     }
     
     // Remove snow at the bottom if necessary
-    for( int i = snowfall.size() - 1; i >= snowfall.size(); i-- ){
+    for( int i = snowfall.size() - 1; i >= 0; i-- ){
       Snow particle = snowfall.get(i);
       
       if( particle.y > height ){


### PR DESCRIPTION
The snow particles weren't being properly removed, leading to insane numbers of particles in the arraylist. This naturally made the performance worse the longer it ran.